### PR TITLE
0.0.4 - Adds specs, flexible input

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Execute one-off gists inline or in the background.
 Gisture.run('c3b478ef0592eacad361')
 ```
 
+For convenience, you can also use gist.github.com URLs, with or without revision information in them
+
+```ruby
+Gisture.run('https://gist.github.com/markrebec/c3b478ef0592eacad361')
+Gisture.run('https://gist.github.com/markrebec/c3b478ef0592eacad361/7714df11a3babaa78f27027844ac2f0c1a8348c1')
+```
+
 The above will run [this gist](https://gist.github.com/markrebec/c3b478ef0592eacad361) and print "You are using Gisture version 0.0.2"
 
 ## Getting Started

--- a/lib/gisture/version.rb
+++ b/lib/gisture/version.rb
@@ -1,3 +1,3 @@
 module Gisture
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/spec/gisture_spec.rb
+++ b/spec/gisture_spec.rb
@@ -1,4 +1,72 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Gisture do
+  describe "testing various inputs" do
+    SAMPLE_GIST_ID = "c3b478ef0592eacad361".freeze
+    SAMPLE_GIST_VERSION = "7714df11a3babaa78f27027844ac2f0c1a8348c1".freeze
+    SAMPLE_GIST_URL = "https://gist.github.com/markrebec/#{SAMPLE_GIST_ID}".freeze
+    SAMPLE_GIST_URL_WITH_VERSION = "https://gist.github.com/markrebec/#{SAMPLE_GIST_ID}/#{SAMPLE_GIST_VERSION}".freeze
+    DEFAULT_NEW_GIST_ARGS = {gist_id: nil, strategy: nil, filename: nil, version: nil}
+
+    it "throws an error with missing input" do
+      expect { Gisture::Gist.parse_gist_id() }.
+        to raise_error(ArgumentError)
+    end
+
+    describe "passed a string" do
+
+      it "works with a gist ID" do
+        expect(Gisture::Gist.parse_gist_id(SAMPLE_GIST_ID)).
+          to eq(SAMPLE_GIST_ID)
+      end
+
+      it "works with a gist ID and a version parameter" do
+        expect(Gisture::Gist.parse_gist_id(SAMPLE_GIST_ID)).
+          to eq(SAMPLE_GIST_ID)
+        expect(Gisture::Gist.
+                parse_version(gist_id: SAMPLE_GIST_ID,
+                              version: SAMPLE_GIST_VERSION)).
+          to eq(SAMPLE_GIST_VERSION)
+      end
+
+      it "throws an error with a bad string" do
+        expect { Gisture::Gist.parse_gist_id('123') }.
+          to raise_error(ArgumentError)
+      end
+    end
+
+    describe "passed a non-string" do
+      it "converts a valid non-string" do
+        expect(Gisture::Gist.parse_gist_id(SAMPLE_GIST_ID.to_sym)).
+          to eq(SAMPLE_GIST_ID)
+      end
+
+      it "throws an error with a bad non-string" do
+        expect { Gisture::Gist.parse_gist_id(123) }.
+          to raise_error(ArgumentError)
+      end
+    end
+
+    describe "takes a gist URL as input, with a gist ID and" do
+      it "without a version" do
+        expect(Gisture::Gist.parse_gist_id(SAMPLE_GIST_URL)).
+          to eq(SAMPLE_GIST_ID)
+      end
+
+      it "with a version" do
+        expect(Gisture::Gist.parse_gist_id(SAMPLE_GIST_URL_WITH_VERSION)).
+          to eq(SAMPLE_GIST_ID)
+        expect(Gisture::Gist.
+                parse_version(gist_id: SAMPLE_GIST_URL_WITH_VERSION)).
+          to eq(SAMPLE_GIST_VERSION)
+      end
+
+      it "throws an error with differing versions" do
+        expect { Gisture::Gist.
+                 parse_version(gist_id: SAMPLE_GIST_URL_WITH_VERSION,
+                               version: SAMPLE_GIST_VERSION) }.
+          to raise_error(ArgumentError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
@markrebec Here's a first-pass at allowing people to paste in the gist URL, with or without version information.

I created instance methods for easier testing of this parsing in isolation.

I look forward to your feedback.
